### PR TITLE
Fix messages

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -22,7 +22,7 @@
 	"cpd-api-save-diagram-param-xml": "JSON encoded XML to be uploaded to wiki",
 	"cpd-api-save-diagram-param-process-id": "ID of the BPMN diagram",
 	"cpd-api-save-diagram-error-message": "Error while saving the diagram: $1",
-	"cpd-api-save-description-pages-success-message": "{{PLURAL:$1|The following $1|The following $1|0=No}} description {{PLURAL:$1|page|pages}} have been saved:",
+	"cpd-api-save-description-pages-success-message": "{{PLURAL:$1|1=The following description page has|The following $1 description pages have|0=No description pages have}} been saved:",
 	"cpd-description-page-does-not-exist-anymore-warning": "Description page $1 does not exist anymore",
 	"cpd-description-page-has-no-property-warning": "Element $1 has no description page property",
 	"cpd-api-save-description-pages-error-message": "Error while saving description pages: $1",
@@ -98,5 +98,5 @@
 	"cpd-api-save-description-page-comment": "Description page saved",
 	"cpd-api-move-description-page-comment": "Description page moved",
 	"cpd-config-canvas-process-height-msg": "Set the height of the diagram canvas on the process page and in edit mode",
-	"cpd-config-canvas-embedded-height-msg": "Set the height of the diagram canvas while its embedded in other pages"
+	"cpd-config-canvas-embedded-height-msg": "Set the height of the diagram canvas while it is embedded in other pages"
 }


### PR DESCRIPTION
1. This fixes English grammar (you need "has" with 1). It also prevents translatewiki.net's validation functions from marking this message as invalid— in the old form, it has two identical strings in both parts, which is discouraged and generates a warning.

2. Fix "its" to "it is".